### PR TITLE
completed virtualpad pressure sensitivity implementation

### DIFF
--- a/pcsx2/Sio.cpp
+++ b/pcsx2/Sio.cpp
@@ -177,9 +177,18 @@ SIO_WRITE sioWriteController(u8 data)
 	default: 
 		sio.buf[sio.bufCount] = PADpoll(data);
 
+		//--TAS--//
+		g_KeyMovie.ControllerInterrupt(data, sio.port,sio.bufCount,sio.buf);
+
+		//--LuaEngine--//
+		if (g_KeyMovie.isInterruptFrame()) {
+			g_TASInput.ControllerInterrupt(data, sio.port, sio.bufCount, sio.buf);
+		}
+		//------------//
+
 		// -- TAS Debugging Helpful -- //
 		// Prints controlller data every frame //
-		/*
+		/* TODO TAS - move this to a settings flag in the console or something instead of having to uncomment
 		std::string converted = std::to_string(sio.buf[sio.bufCount]);
 		if (sio.port == 0 && sio.bufCount > 2) { // skip first two bytes because they dont seem to matter
 			if (sio.bufCount == 3) {
@@ -195,16 +204,6 @@ SIO_WRITE sioWriteController(u8 data)
 			std::cout << converted << " ";
 		}
 		*/
-
-
-		//--TAS--//
-		g_KeyMovie.ControllerInterrupt(data, sio.port,sio.bufCount,sio.buf);
-
-		//--LuaEngine--//
-		if (g_KeyMovie.isInterruptFrame()) {
-			g_TASInput.ControllerInterrupt(data, sio.port, sio.bufCount, sio.buf);
-		}
-		//------------//
 
 		break;
 	}

--- a/pcsx2/TAS/PadData.cpp
+++ b/pcsx2/TAS/PadData.cpp
@@ -78,7 +78,7 @@ std::map<wxString, int> PadData::getNormalKeys(int port)const
 	std::map<wxString, int> key;
 	for (int i = 0; i < PadDataNormalKeysSize; i++)
 	{
-		key.insert(std::map<wxString, u8>::value_type(PadDataNormalKeys[i], getNormalButton(port, PadDataNormalKeys[i])));
+		key.insert(std::map<wxString, int>::value_type(PadDataNormalKeys[i], getNormalButton(port, PadDataNormalKeys[i])));
 	}
 	return key;
 }

--- a/pcsx2/TAS/PadData.h
+++ b/pcsx2/TAS/PadData.h
@@ -47,7 +47,7 @@ public:
 public:
 
 	bool fExistKey = false;
-	u8 buf[2][6];
+	u8 buf[2][18];
 	
 public:
 	wxString serialize()const;
@@ -73,6 +73,7 @@ private:
 	void setNormalButton(int port, wxString button, int pressure);
 	int getNormalButton(int port, wxString button)const;
 	void getKeyBit(byte keybit[2], wxString button)const;
+	int getPressureByte(wxString button)const;
 
 	void setAnalogButton(int port, wxString button, int push);
 	int getAnalogButton(int port, wxString button)const;

--- a/pcsx2/TAS/TASInputManager.cpp
+++ b/pcsx2/TAS/TASInputManager.cpp
@@ -21,25 +21,31 @@ void TASInputManager::ControllerInterrupt(u8 & data, u8 & port, u16 & BufCount, 
 	if (virtualPad[port])
 	{
 		int bufIndex = BufCount - 3;
-		if (bufIndex < 0 || 6 < bufIndex)
+		// first two bytes have nothing of interest in the buffer
+		// already handled by KeyMovie.cpp
+		if (BufCount < 3)
 			return;
+
 		// Normal keys
 		// We want to perform an OR, but, since 255 means that no button is pressed and 0 that every button is pressed (and by De Morgan's Laws), we execute an AND.
-		if (bufIndex <= 1)
-			buf[BufCount] = buf[BufCount] & pad.buf[port][bufIndex];
+		if (BufCount <= 4)
+			buf[BufCount] = buf[BufCount] & pad.buf[port][BufCount - 3];
 		// Analog keys (! overrides !)
-		else if (pad.buf[port][bufIndex] != 127)
-			buf[BufCount] = pad.buf[port][bufIndex];
+		else if ((BufCount > 4 && BufCount <= 6) && pad.buf[port][BufCount - 3] != 127)
+			buf[BufCount] = pad.buf[port][BufCount - 3];
+		// Pressure sensitivity bytes
+		else if (BufCount > 6)
+			buf[BufCount] = pad.buf[port][BufCount - 3];
 
 		// Updating movie file
 		g_KeyMovie.ControllerInterrupt(data, port, BufCount, buf);
 	}
 }
 
-void TASInputManager::SetButtonState(int port, wxString button, bool state)
+void TASInputManager::SetButtonState(int port, wxString button, int pressure)
 {
 	auto normalKeys = pad.getNormalKeys(port);
-	normalKeys.at(button) = state;
+	normalKeys.at(button) = pressure;
 	pad.setNormalKeys(port, normalKeys);
 }
 

--- a/pcsx2/TAS/TASInputManager.h
+++ b/pcsx2/TAS/TASInputManager.h
@@ -9,7 +9,7 @@ public:
 	void ControllerInterrupt(u8 &data, u8 &port, u16 & BufCount, u8 buf[]);
 
 	// Handles normal keys
-	void SetButtonState(int port, wxString button, bool state);
+	void SetButtonState(int port, wxString button, int pressure);
 
 	// Handles analog sticks
 	void UpdateAnalog(int port, wxString key, int value);

--- a/pcsx2/TAS/VirtualPad.h
+++ b/pcsx2/TAS/VirtualPad.h
@@ -27,8 +27,13 @@ protected:
 
 	void OnClick(wxCommandEvent &event);
 	void OnResetButton(wxCommandEvent &event);
+	void OnPressureCtrlChange(wxSpinEvent &event);
 	void OnTextCtrlChange(wxSpinEvent &event);
 	void OnSliderMove(wxCommandEvent &event);
+
+	int getButtonIdFromPressure(int pressureCtrlId);
+
+	bool isPressureSensitive(int buttonId);
 
 	wxDECLARE_EVENT_TABLE();
 };


### PR DESCRIPTION
closes #4

* made the pressure sensitive information actually propagate its way to the controllerinterrupt.
* also added another eventlistener so you don't have to repress the button to change the sensitivity.
* removed pressure sensitive controls (that were hidden in the UI) from buttons that do not have sensitivity support.
